### PR TITLE
refactoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## dev
+
+- current container is stored to context var
+- removed container name and storing all containers
+- make_default is renamed to use_container
+- Resolvers are moved to resolvers module
+
 ## 1.1.2
 
 - @dependency uses own implementation by default

--- a/injectool/__init__.py
+++ b/injectool/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = '1.1.2'
 
-from .core import DependencyError, Container, SingletonResolver, FunctionResolver
-from .core import make_default, add_resolver, add_singleton, add_function_resolver, resolve
+from .core import DependencyError, Resolver, Container
+from .resolvers import SingletonResolver, FunctionResolver
+from .resolvers import add_resolver, add_singleton, add_function_resolver, add_type
 from .injection import inject, dependency

--- a/injectool/core.py
+++ b/injectool/core.py
@@ -56,15 +56,17 @@ class Container:
         return new
 
 
-container_var = ContextVar('container')
+_CURRENT_CONTAINER = ContextVar('container')
 
 
 def set_container(container: Container):
-    container_var.set(container)
+    """Sets container used for resolving and registering dependencies"""
+    _CURRENT_CONTAINER.set(container)
 
 
 def get_container() -> Container:
-    return container_var.get()
+    """Returns container used for resolving and registering dependencies"""
+    return _CURRENT_CONTAINER.get()
 
 
 @contextmanager
@@ -74,13 +76,13 @@ def use_container(container: Container = None) -> Container:
     Creates new if container doesn't exist.
     """
     container = container if container else Container()
-    reset_token = container_var.set(container)
+    reset_token = _CURRENT_CONTAINER.set(container)
     try:
         yield container
     finally:
-        container_var.reset(reset_token)
+        _CURRENT_CONTAINER.reset(reset_token)
 
 
 def resolve(dependency: Union[str, Callable], param: Any = None):
-    """resolves dependency using"""
+    """resolves dependency"""
     return get_container().resolve(dependency, param)

--- a/injectool/resolvers.py
+++ b/injectool/resolvers.py
@@ -1,0 +1,53 @@
+from typing import Any, Callable, Union, Type
+
+from injectool.core import Resolver, DependencyError, Container, get_container
+
+
+class SingletonResolver(Resolver):
+    """Singleton resolver"""
+
+    def __init__(self, value: Any = None, param: Any = None):
+        self._values = {}
+        if value is not None:
+            self.set_value(value, param)
+
+    def set_value(self, value: Any, param: Any):
+        """Sets value for parameter"""
+        self._values[param] = value
+
+    def resolve(self, container: Container, param: Any = None):
+        try:
+            return self._values[param]
+        except KeyError:
+            raise DependencyError(f'Singleton value for parameter {param} is not found')
+
+
+class FunctionResolver(Resolver):
+    """Function resolver"""
+
+    def __init__(self, resolve_: Callable[[Container, Any], Any]):
+        self._resolve = resolve_
+
+    def resolve(self, container: Container, param: Any = None):
+        return self._resolve(container, param)
+
+
+def add_resolver(dependency: Union[str, Callable], resolver: Resolver):
+    """Adds resolver to current container"""
+    get_container().set(dependency, resolver)
+
+
+def add_singleton(dependency: Union[str, Callable], value: Any):
+    """Adds singleton value to current container"""
+    get_container().set(dependency, SingletonResolver(value))
+
+
+def add_function_resolver(dependency: Union[str, Callable],
+                          resolve_: Callable[[Container, Any], Any]):
+    """Adds function resolver to current container"""
+    get_container().set(dependency, FunctionResolver(resolve_))
+
+
+def add_type(dependency: Union[str, Callable], type_: Type):
+    """Adds type resolver to current container"""
+    add_function_resolver(dependency, lambda c, p=None: type_())

--- a/injectool/resolvers.py
+++ b/injectool/resolvers.py
@@ -1,3 +1,5 @@
+"""Dependency resolvers used by container"""
+
 from typing import Any, Callable, Union, Type
 
 from injectool.core import Resolver, DependencyError, Container, get_container

--- a/injectool/tests/core_tests.py
+++ b/injectool/tests/core_tests.py
@@ -1,10 +1,11 @@
 from unittest.mock import Mock, call
 
-from pytest import raises, mark, fixture, fail
+from pytest import raises, mark, fixture
 
-from injectool import Container, DependencyError
-from injectool.core import get_dependency_key, SingletonResolver, FunctionResolver, add_type
-from injectool.core import make_default, add_resolver, add_singleton, add_function_resolver, resolve
+from injectool.core import Container, DependencyError
+from injectool.core import get_dependency_key, use_container, get_container, set_container
+from injectool.core import resolve
+from injectool.resolvers import SingletonResolver, FunctionResolver, add_resolver
 
 
 @mark.parametrize('dependency, key', [
@@ -17,113 +18,23 @@ def test_get_dependency_key(dependency, key):
     assert get_dependency_key(dependency) == key
 
 
-class SingletonResolverTests:
-    """Singleton resolver class tests"""
-
-    @staticmethod
-    @mark.parametrize('def_value, def_param, value, param', [
-        (1, None, 2, SingletonResolver),
-        ({}, SingletonResolver, {'key': 1}, None),
-        ([], 1, ['value'], 'parameter')
-    ])
-    def tests_adds_value_for_parameter(def_value, def_param, value, param):
-        """should add single value for parameter"""
-        resolver = SingletonResolver(def_value, def_param)
-
-        resolver.set_value(value, param)
-
-        assert resolver.resolve(Mock(), def_param) == def_value
-        assert resolver.resolve(Mock(), param) == value
-
-    @staticmethod
-    @mark.parametrize('param', [SingletonResolver, None, 'parameter'])
-    def test_resolve_raises_for_unknown_param(param):
-        resolver = SingletonResolver()
-
-        with raises(DependencyError):
-            resolver.resolve(param)
-
-
-class FunctionResolverTests:
-    """FunctionResolver class tests"""
-
-    @staticmethod
-    def test_calls_passed_function():
-        """resolve() should call passed function with resolve parameters"""
-        func, container, param = Mock(), Mock(), Mock()
-        resolver = FunctionResolver(func)
-
-        resolver.resolve(container, param)
-
-        assert func.call_args == call(container, param)
-
-    @staticmethod
-    @mark.parametrize('value', ['value', None, 1])
-    def test_returns_dependency(value):
-        """resolve() should call passed function with resolve parameters"""
-        container = Mock()
-        resolver = FunctionResolver(lambda c, p=None: value)
-
-        assert resolver.resolve(container) == value
-
-
 @fixture
 def container_fixture(request):
-    Container._containers = {}
-    Container('')
-    request.cls.container = Container('test_container')
+    with use_container() as container:
+        request.cls.container = container
+        yield container
 
 
 @mark.usefixtures('container_fixture')
 class ContainerTests:
-    """Container class tests"""
-
-    @staticmethod
-    @mark.parametrize('name', ['container', 'other container'])
-    def test_name(name):
-        """__init__ should setup name"""
-        container = Container(name)
-
-        assert container.name == name
-
-    @staticmethod
-    @mark.parametrize('name', ['container', 'other container'])
-    def test_container_name_unique(name):
-        """Container name should be unique"""
-        Container(name)
-        with raises(DependencyError):
-            Container(name)
-
-    @staticmethod
-    def test_get_default():
-        """get() returns default container"""
-        assert Container.get() == Container.get('')
-
-    @staticmethod
-    @mark.parametrize('name', ['name', 'another name'])
-    def test_get_named(name):
-        """get() returns container by name"""
-        container = Container(name)
-
-        assert Container.get(name) == container
-
-    @staticmethod
-    def test_get_raises():
-        """get() should raise DependencyError if container not found"""
-        with raises(DependencyError):
-            Container.get('some container')
-
-
-@mark.usefixtures('container_fixture')
-class ContainerAddResolverTests:
     @mark.parametrize('dependency, resolver', [
         ('key', Mock()),
         (get_dependency_key, SingletonResolver),
         (Container, FunctionResolver)
     ])
-    def test_add(self, dependency, resolver):
+    def test_set(self, dependency, resolver):
         """Container should set resolver for dependency"""
-        self.container.add(dependency, resolver)
+        self.container.set(dependency, resolver)
 
         assert self.container.get_resolver(dependency) == resolver
 
@@ -134,8 +45,8 @@ class ContainerAddResolverTests:
     ])
     def test_last_resolver(self, dependency, resolver, last_resolver):
         """Container should overwrite resolver for same dependency"""
-        self.container.add(dependency, resolver)
-        self.container.add(dependency, last_resolver)
+        self.container.set(dependency, resolver)
+        self.container.set(dependency, last_resolver)
 
         assert self.container.get_resolver(dependency) == last_resolver
 
@@ -144,9 +55,6 @@ class ContainerAddResolverTests:
         """get_resolver() should return none for not existent dependency"""
         assert self.container.get_resolver(dependency) is None
 
-
-@mark.usefixtures('container_fixture')
-class ContainerResolveTests:
     @mark.parametrize('dependency, param', [
         ('key', None),
         (get_dependency_key, 'param'),
@@ -157,7 +65,7 @@ class ContainerResolveTests:
         result = Mock()
         resolver = Mock(resolve=Mock())
         resolver.resolve.side_effect = lambda c, p: result
-        self.container.add(dependency, resolver)
+        self.container.set(dependency, resolver)
 
         actual = self.container.resolve(dependency, param)
 
@@ -170,9 +78,6 @@ class ContainerResolveTests:
         with raises(DependencyError):
             self.container.resolve(dependency)
 
-
-@mark.usefixtures('container_fixture')
-class ContainerCopyTests:
     @mark.parametrize('dependency, value', [
         ('key', lambda: None),
         (get_dependency_key, 1),
@@ -180,32 +85,11 @@ class ContainerCopyTests:
     ])
     def test_copy(self, dependency, value):
         """copy() should return new Container with same dependencies"""
-        self.container.add(dependency, SingletonResolver(value))
+        self.container.set(dependency, SingletonResolver(value))
 
         actual = self.container.copy()
 
         assert actual.resolve(dependency) == value
-
-    @staticmethod
-    @mark.parametrize('source_name, expected_name', [
-        ('', '_copy'),
-        ('name', 'name_copy'),
-        ('another name', 'another name_copy')
-    ])
-    def test_copy_sets_name(source_name, expected_name):
-        """copy() should return new Container with same dependencies"""
-        container = Container.get() if source_name == '' else Container(source_name)
-
-        actual = container.copy()
-
-        assert actual.name == expected_name
-
-    @mark.parametrize('name', ['name', 'another name'])
-    def test_copy_sets_passed_name(self, name):
-        """copy() should return new Container with same dependencies"""
-        actual = self.container.copy(name)
-
-        assert actual.name == name
 
     @mark.parametrize('dependency, value', [
         ('key', lambda: None),
@@ -216,121 +100,55 @@ class ContainerCopyTests:
         """copy() should return new Container with same dependencies"""
         copy = self.container.copy()
 
-        self.container.add(dependency, SingletonResolver(value))
+        self.container.set(dependency, SingletonResolver(value))
 
         with raises(DependencyError):
             assert copy.resolve(dependency)
 
     def test_copy_for_new_dependencies(self):
         """dependencies for copied container does not affect parent"""
-        self.container.add('value', SingletonResolver(0))
+        self.container.set('value', SingletonResolver(0))
         copy = self.container.copy()
 
-        copy.add('value', SingletonResolver(1))
+        copy.set('value', SingletonResolver(1))
 
         assert self.container.resolve('value') == 0
         assert copy.resolve('value') == 1
 
 
+def test_get_set_container():
+    """get should return current container"""
+    container = Container()
+
+    set_container(container)
+    actual = get_container()
+
+    assert container == actual
+
+
 @mark.usefixtures('container_fixture')
-class MakeDefaultTests:
+class UseContainerTests:
     """DefaultContainerContext class tests"""
 
     @staticmethod
-    @mark.parametrize('name', ['container', 'other container'])
-    def test_creates_container(name):
-        """__init__ should create container with provided name"""
-        with make_default(name) as container:
-            assert Container.get(name) == container
+    def test_creates_container():
+        """should create new container and use it"""
+        container = get_container()
+        with use_container() as actual:
+            assert actual is not None
+            assert actual != container
+            assert get_container() == actual
+        assert get_container() == container
 
     @staticmethod
-    @mark.parametrize('name', ['container', 'other container'])
-    def test_uses_existing_container(name):
-        """__init__ should use existing container with provided name"""
-        Container(name)
-        try:
-            with make_default(name):
-                pass
-        except DependencyError:
-            fail()
-
-    @staticmethod
-    @mark.parametrize('name', ['container', 'other container'])
-    def test_sets_container_default_in_context(name):
-        """__enter__ should make container default in context"""
-        with make_default(name) as container:
-            assert Container.get() == container
-
-    @staticmethod
-    @mark.parametrize('previous_name, next_name', [('container', 'other container')])
-    def test_restores_previous_default(previous_name, next_name):
-        """__exit__ should make previous default container default again"""
-        default_container = Container.get()
-        with make_default(previous_name) as previous_container:
-            with make_default(next_name) as next_container:
-                assert Container.get() == next_container
-            assert Container.get() == previous_container
-        assert Container.get() == default_container
-
-
-@mark.parametrize('dependency, resolver', [
-    ('key', FunctionResolver(lambda: 'value')),
-    (get_dependency_key, SingletonResolver(1)),
-    (Container, Mock())
-])
-def test_add_resolver(dependency, resolver):
-    """add_resolver() should add dependency resolver to current container"""
-    with make_default('test_add') as container:
-        add_resolver(dependency, resolver)
-
-        assert container.get_resolver(dependency) == resolver
-
-
-@mark.parametrize('dependency, value', [
-    ('key', lambda c, param=None: 'value'),
-    (get_dependency_key, 1),
-    (Container, Mock())
-])
-def test_add_singleton(dependency, value):
-    """add_singleton() should add SingletonResolver to current container"""
-    with make_default('test_add_singleton') as container:
-        add_singleton(dependency, value)
-
-        resolver = container.get_resolver(dependency)
-        assert isinstance(resolver, SingletonResolver)
-        assert resolver.resolve(container) == value
-
-
-@mark.parametrize('dependency, function', [
-    ('key', lambda c, p=None: 'value'),
-    (get_dependency_key, lambda c, p=None: 1)
-])
-def test_add_function_resolver(dependency, function):
-    """should add FunctionResolver to current container"""
-    with make_default('test_add_resolve_function') as container:
-        add_function_resolver(dependency, function)
-
-        resolver = container.get_resolver(dependency)
-        assert isinstance(resolver, FunctionResolver)
-        assert resolver.resolve(container) == function(container)
-
-
-class TestType:
-    pass
-
-
-@mark.parametrize('dependency, type_', [
-    (TestType, TestType)
-])
-def test_add_type(dependency, type_):
-    """add_type() should add type resolver to current container"""
-    with make_default('test_add_resolve_function') as container:
-        add_type(dependency, TestType)
-        resolver = container.get_resolver(dependency)
-
-        actual = resolver.resolve(container)
-
-        assert isinstance(actual, type_)
+    def test_uses_passed_container():
+        """should create new container and use it"""
+        container = get_container()
+        new_container = Container()
+        with use_container(new_container) as actual:
+            assert actual == new_container
+            assert get_container() == actual
+        assert get_container() == container
 
 
 @mark.parametrize('dependency, resolver', [
@@ -339,7 +157,7 @@ def test_add_type(dependency, type_):
 ])
 def test_resolve(dependency, resolver):
     """resolve() should resolve dependency using current container"""
-    with make_default('test_resolve') as container:
+    with use_container() as container:
         add_resolver(dependency, resolver)
 
         assert resolve(dependency) == container.resolve(dependency)

--- a/injectool/tests/injection_tests.py
+++ b/injectool/tests/injection_tests.py
@@ -2,14 +2,14 @@ from unittest.mock import Mock
 
 from pytest import mark, fixture
 
-from injectool.core import make_default, Container, get_dependency_key, add_singleton
+from injectool.core import use_container, Container, get_dependency_key
 from injectool.injection import inject, dependency
+from injectool.resolvers import add_singleton
 
 
 @fixture
 def inject_fixture():
-    name = 'inject_tests'
-    with make_default(name) as container:
+    with use_container() as container:
         yield container
 
 

--- a/injectool/tests/resolvers_tests.py
+++ b/injectool/tests/resolvers_tests.py
@@ -1,0 +1,117 @@
+from unittest.mock import Mock, call
+
+from pytest import mark, raises
+
+from injectool.core import get_dependency_key, Container, use_container, DependencyError
+from injectool.resolvers import SingletonResolver, FunctionResolver, add_singleton, add_function_resolver, add_type, \
+    add_resolver
+
+
+class SingletonResolverTests:
+    """Singleton resolver class tests"""
+
+    @staticmethod
+    @mark.parametrize('def_value, def_param, value, param', [
+        (1, None, 2, SingletonResolver),
+        ({}, SingletonResolver, {'key': 1}, None),
+        ([], 1, ['value'], 'parameter')
+    ])
+    def tests_adds_value_for_parameter(def_value, def_param, value, param):
+        """should add single value for parameter"""
+        resolver = SingletonResolver(def_value, def_param)
+
+        resolver.set_value(value, param)
+
+        assert resolver.resolve(Mock(), def_param) == def_value
+        assert resolver.resolve(Mock(), param) == value
+
+    @staticmethod
+    @mark.parametrize('param', [SingletonResolver, None, 'parameter'])
+    def test_resolve_raises_for_unknown_param(param):
+        resolver = SingletonResolver()
+
+        with raises(DependencyError):
+            resolver.resolve(param)
+
+
+class FunctionResolverTests:
+    """FunctionResolver class tests"""
+
+    @staticmethod
+    def test_calls_passed_function():
+        """resolve() should call passed function with resolve parameters"""
+        func, container, param = Mock(), Mock(), Mock()
+        resolver = FunctionResolver(func)
+
+        resolver.resolve(container, param)
+
+        assert func.call_args == call(container, param)
+
+    @staticmethod
+    @mark.parametrize('value', ['value', None, 1])
+    def test_returns_dependency(value):
+        """resolve() should call passed function with resolve parameters"""
+        container = Mock()
+        resolver = FunctionResolver(lambda c, p=None: value)
+
+        assert resolver.resolve(container) == value
+
+
+@mark.parametrize('dependency, resolver', [
+    ('key', FunctionResolver(lambda: 'value')),
+    (get_dependency_key, SingletonResolver(1)),
+    (Container, Mock())
+])
+def test_add_resolver(dependency, resolver):
+    """add_resolver() should add dependency resolver to current container"""
+    with use_container() as container:
+        add_resolver(dependency, resolver)
+
+        assert container.get_resolver(dependency) == resolver
+
+
+@mark.parametrize('dependency, value', [
+    ('key', lambda c, param=None: 'value'),
+    (get_dependency_key, 1),
+    (Container, Mock())
+])
+def test_add_singleton(dependency, value):
+    """add_singleton() should add SingletonResolver to current container"""
+    with use_container() as container:
+        add_singleton(dependency, value)
+
+        resolver = container.get_resolver(dependency)
+        assert isinstance(resolver, SingletonResolver)
+        assert resolver.resolve(container) == value
+
+
+@mark.parametrize('dependency, function', [
+    ('key', lambda c, p=None: 'value'),
+    (get_dependency_key, lambda c, p=None: 1)
+])
+def test_add_function_resolver(dependency, function):
+    """should add FunctionResolver to current container"""
+    with use_container() as container:
+        add_function_resolver(dependency, function)
+
+        resolver = container.get_resolver(dependency)
+        assert isinstance(resolver, FunctionResolver)
+        assert resolver.resolve(container) == function(container)
+
+
+class TestType:
+    pass
+
+
+@mark.parametrize('dependency, type_', [
+    (TestType, TestType)
+])
+def test_add_type(dependency, type_):
+    """add_type() should add type resolver to current container"""
+    with use_container() as container:
+        add_type(dependency, TestType)
+        resolver = container.get_resolver(dependency)
+
+        actual = resolver.resolve(container)
+
+        assert isinstance(actual, type_)


### PR DESCRIPTION
- current container is stored to context var
- removed container name and storing all containers
- make_default is renamed to use_container
- Resolvers are moved to resolvers module